### PR TITLE
Eliminated the warning message caused by spec

### DIFF
--- a/spec/ruby_basics_spec.rb
+++ b/spec/ruby_basics_spec.rb
@@ -40,7 +40,7 @@ describe "ruby" do
     it 'raises an error with one argument' do
       greeting = "Hi there, "
 
-      expect{ greeting(greeting)}.to raise_error
+      expect{ greeting(greeting)}.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
There was a warning message thrown about no error type. I added (ArgumentError) on line 43 because that is the expected error.

Closes #21 

#staff